### PR TITLE
Update Maven repository URL to HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         </repository>
         <repository>
             <id>sk89q-repo</id>
-            <url>http://maven.enginehub.org/repo/</url>
+            <url>https://maven.enginehub.org/repo/</url>
         </repository>
         <repository>
             <id>jitpack.io</id>


### PR DESCRIPTION
The Maven repository URL for sk89q has been updated from HTTP to HTTPS, to ensure that all artifacts are securely downloaded. This change improves security measures while downloading dependencies.