### PR TITLE
Remove clone method

### DIFF
--- a/src/main/java/com/Acrobot/ChestShop/Events/PreShopCreationItemDisplayNameEvent.java
+++ b/src/main/java/com/Acrobot/ChestShop/Events/PreShopCreationItemDisplayNameEvent.java
@@ -23,7 +23,7 @@ public class PreShopCreationItemDisplayNameEvent extends Event {
     }
 
     public ItemStack getItemStack() {
-        return itemStack.clone();
+        return itemStack;
     }
 
     public String getDisplayName() {


### PR DESCRIPTION
Removed clone Method from PreShopCreationItemDisplayNameEvent. When many plugins use this event to define custom names the performance was very poor.